### PR TITLE
Fix wrong clarification of date format

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -24,7 +24,7 @@
                 "format":"uri" 
               },
               "birthday":{
-                "description": "Birthday in format dd.mm.yyyy",
+                "description": "Birthday in format yyyy-mm-dd",
                 "type":"string",
                 "format": "date"
               },


### PR DESCRIPTION
As JSON Schema [specifies](https://json-schema.org/understanding-json-schema/reference/string.html#dates-and-times), `date` format must match format `yyyy-mm-dd` (eg. `2019-12-31`) instead of `dd.mm.yyyy` (eg. `31.12.2019`)`.