### PR TITLE
fix: fix markdown link masking

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You can check **examples of how to use code to create and validate MAC files** i
 
 ---
 
-The Schema is documented by itself, but it's much easier to get "the big picture" with [a graphical representation].(https://github.com/getmanfred/mac/blob/master/assets/readme/MAC_diagram.png)
+The Schema is documented by itself, but it's much easier to get "the big picture" with [a graphical representation](https://github.com/getmanfred/mac/blob/master/assets/readme/MAC_diagram.png).
 <br />
 <br />
 


### PR DESCRIPTION
Moved the `.` to the end of link's closing bracket, so that it works as intended