### PR TITLE
Feature/add tox and fix pep8 errors

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+      - name: Package installation
+        run: apk add --no-cache python3 py3-pip && pip3 install tox
+      - name: Tox call tests
+        run: tox -v
+

--- a/scripts/python_validator/jsonschema_generator.py
+++ b/scripts/python_validator/jsonschema_generator.py
@@ -3,7 +3,6 @@ import argparse
 import json
 import logging
 
-import jsonschema
 import yaml
 from faker import Faker
 
@@ -25,7 +24,8 @@ def init_logging(debug=0):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Generate random data for jsonschema")
+    parser = argparse.ArgumentParser(
+        description="Generate random data for jsonschema")
     parser.add_argument("schema", help="Schema to be used")
     parser.add_argument("-o", "--output", help="Output file")
     parser.add_argument(

--- a/scripts/python_validator/mac_validate.py
+++ b/scripts/python_validator/mac_validate.py
@@ -64,7 +64,8 @@ def reader_builder(filename):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Validate a Manfred Awesomic CV")
+    parser = argparse.ArgumentParser(
+        description="Validate a Manfred Awesomic CV")
     parser.add_argument(
         "filename", nargs="+", help="YAML or JSON files to be validated"
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+minversion = 3.8.0
+skipsdist = True
+envlist = pep8
+
+[testenv:pep8]
+deps = flake8
+commands = flake8 {posargs}
+
+[flake8]
+exclude=.tox


### PR DESCRIPTION
Hello. I've used the generator and it's great :).

I'd like to propose the following:

- Add this tox.ini file to run flake8 under the project. We can ensure at this way we're fulfilling PEP8 and avoid these kinds of errors:
```
[2022-03-30 22:05:50] {afuscoar@afuscoar} (~/.Personal/Projects/mac) (master)$ -> tox
pep8 installed: flake8==4.0.1,mccabe==0.6.1,pycodestyle==2.8.0,pyflakes==2.4.0
pep8 run-test-pre: PYTHONHASHSEED='4139552014'
pep8 run-test: commands[0] | flake8
./scripts/python_validator/mac_validate.py:67:80: E501 line too long (82 > 79 characters)
./scripts/python_validator/jsonschema_generator.py:27:80: E501 line too long (87 > 79 characters)
./scripts/python_validator/jsonschema_generator.py:6:1: F401 'jsonschema' imported but unused
ERROR: InvocationError for command /home/afuscoar/.Personal/Projects/mac/.tox/pep8/bin/flake8 (exited with code 1)
```
- Add a workflow to run the pipeline with tox when there's a push or pull request.
- Fix the errors produced by PEP8

Let me know your opinion :). Thx.