### PR TITLE
chore: add twitter and github as contactMean

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -835,6 +835,8 @@
                                             "linkedin",
                                             "stackoverflow",
                                             "xing",
+                                            "twitter",
+                                            "github",
                                             "other"
                                         ],
                                         "$comment": "TBD Refactor to extract the enumeration \"public link type\" to a common definition file, to be completed with more external services."

--- a/typescript/schema.ts
+++ b/typescript/schema.ts
@@ -29,11 +29,11 @@ export type ContactMean =
        */
       publicProfiles: [
         {
-          type: "manfred" | "linkedin" | "stackoverflow" | "xing" | "other";
+          type: "manfred" | "linkedin" | "stackoverflow" | "xing" | "twitter" | "github" | "other";
           URL: string;
         },
         ...{
-          type: "manfred" | "linkedin" | "stackoverflow" | "xing" | "other";
+          type: "manfred" | "linkedin" | "stackoverflow" | "xing" | "twitter" | "github" | "other";
           URL: string;
         }[]
       ];


### PR DESCRIPTION
Add Twitter and GitHub as contactMean.

Available options:
```
"manfred",
"linkedin",
"stackoverflow",
"xing",
"twitter",
"github",
"other"
```