### PR TITLE
chore: unify contactMean and relevantLink types

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -57,9 +57,12 @@
                             "type": {
                                 "type": "string",
                                 "enum": [
+                                    "manfred",
                                     "linkedin",
-                                    "github",
+                                    "stackoverflow",
+                                    "xing",
                                     "twitter",
+                                    "github",
                                     "website",
                                     "other"
                                 ]
@@ -319,7 +322,9 @@
                             "fullName": {
                                 "type": "string",
                                 "$comment": "A human friendly readable language name",
-                                "examples": [ "English"]
+                                "examples": [
+                                    "English"
+                                ]
                             },
                             "level": {
                                 "type": "string",
@@ -845,6 +850,7 @@
                                             "xing",
                                             "twitter",
                                             "github",
+                                            "website",
                                             "other"
                                         ],
                                         "$comment": "TBD Refactor to extract the enumeration \"public link type\" to a common definition file, to be completed with more external services."


### PR DESCRIPTION
## 🧐 Quick context

Unify `contactMean` and `relevantLink` types to make it homogenous.

Final options:

```
"manfred",
"linkedin",
"stackoverflow",
"xing",
"twitter",
"github",
"website",
"other"
```